### PR TITLE
Fix exclusion declaration order of groupId and artifactId

### DIFF
--- a/src/main/java/io/fabric8/maven/MavenJDOMWriter.java
+++ b/src/main/java/io/fabric8/maven/MavenJDOMWriter.java
@@ -1421,8 +1421,8 @@ class MavenJDOMWriter {
     protected void updateExclusion(Exclusion value, String xmlTag, Counter counter, Element element) {
         Element root = element;
         Counter innerCount = new Counter(counter.getDepth() + 1);
-        findAndReplaceSimpleElement(innerCount, root, "artifactId", value.getArtifactId(), null);
         findAndReplaceSimpleElement(innerCount, root, "groupId", value.getGroupId(), null);
+        findAndReplaceSimpleElement(innerCount, root, "artifactId", value.getArtifactId(), null);
     } // -- void updateExclusion(Exclusion, String, Counter, Element)
 
     /**


### PR DESCRIPTION
It's better if MavenJDOMWriter behaves the same way as MavenXpp3Writer